### PR TITLE
Override baseurl in staging for Previews

### DIFF
--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -36,5 +36,5 @@ build:
   - JEKYLL_ENV=production
   preview_output_directory: _site
   output_directory: _site
-  instant_preview_command: bundle exec jekyll serve --drafts --unpublished --future
+  instant_preview_command: bundle exec jekyll serve --config _config.yml,_config_staging.yml --drafts --unpublished --future
     --port 8080 --host 0.0.0.0 -d _site

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,0 +1,7 @@
+# Staging server config 
+# This config is only used for the development server
+# No settings provided here will affect production builds
+
+baseurl: ""
+host: 0.0.0.0
+port: 8080


### PR DESCRIPTION
To get instant previews to work without breaking deploy to GitHub Pages

`bundle exec jekyll serve --config _config.yml,_config_staging.yml --drafts --unpublished --future
    --port 8080 --host 0.0.0.0 -d _site`

/cc @dwalkr 